### PR TITLE
Container name shouldn't be hardcoded as it depends on the NAME parameter

### DIFF
--- a/openshift/templates/rails-postgresql-persistent.json
+++ b/openshift/templates/rails-postgresql-persistent.json
@@ -165,7 +165,7 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "rails-pgsql-persistent"
+                "${NAME}"
               ],
               "from": {
                 "kind": "ImageStreamTag",
@@ -191,7 +191,7 @@
           "spec": {
             "containers": [
               {
-                "name": "rails-pgsql-persistent",
+                "name": "${NAME}",
                 "image": " ",
                 "ports": [
                   {

--- a/openshift/templates/rails-postgresql.json
+++ b/openshift/templates/rails-postgresql.json
@@ -165,7 +165,7 @@
             "imageChangeParams": {
               "automatic": true,
               "containerNames": [
-                "rails-postgresql-example"
+                "${NAME}"
               ],
               "from": {
                 "kind": "ImageStreamTag",
@@ -191,7 +191,7 @@
           "spec": {
             "containers": [
               {
-                "name": "rails-postgresql-example",
+                "name": "${NAME}",
                 "image": " ",
                 "ports": [
                   {


### PR DESCRIPTION
Currently, the container name is hardcoded as "rails-pgsql-persistent" which
is the default value. However, if user changes the default value in NAME, then
the container name is not matched which causes the failure due to the container
can't be found.

The container name should n't be hardcoded as it should be based on the NAME
parameter that is provided and modified by user.

Signed-off-by: Vu Dinh <vdinh@redhat.com>