### PR TITLE
Fix ActionController::RoutingError

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,8 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
I experienced following issue.
https://stackoverflow.com/questions/7829480/no-route-matches-get-assets

When we use puma in production mode,  we should set config.public_file_server.enabled to true.
http://edgeguides.rubyonrails.org/configuring.html