### PR TITLE
Update ffi version for multi-arch support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     concurrent-ruby (1.0.5)
     erubi (1.6.0)
     execjs (2.7.0)
-    ffi (1.9.18)
+    ffi (1.9.25)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     i18n (0.8.4)


### PR DESCRIPTION
Ultimately, it would be better to add libffi-devel to the ruby S2I image, but in the meantime updating to the latest 1.9 allows this to successfully build on all supported architectures.

Re: https://github.com/openshift/cluster-samples-operator/pull/225
CC: @gabemontero 