### PR TITLE
Remove BUNDLED_WITH

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,3 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-
-BUNDLED WITH
-   1.16.1


### PR DESCRIPTION
Remove BUNDLED WITH from Gemfile.lock

to maintain compatibility for Bundler 1+2.
This enables the app to be used with Ruby 2.7, as well as with Ruby 2.6 and
earlier.

More context: Ruby 2.7 is shipped with Bundler 2 which requires Gemfile.lock
update (bundle update --bundler) to be able to work with it. That regenerated
Gemfile.lock is howerver not usable with Bundler 1 (shipped with Ruby 2.6 and
earlier) anymore. BUNDLED WITH removal works around this issue.
https://fedoraproject.org/wiki/Changes/Bundler_2.0

_ _ _ _

Makes this repo compatible with Ruby 2.7.

Test log: https://gist.githubusercontent.com/pvalena/8c6bf752e31ea31a20823e23be6788bf/raw/78bbfba4ab64d298fe9c3f491b23d0a376b40dbf/my-screen.log
(run the same way as [here](https://gist.github.com/pvalena/cc6bf3cfad746d944a287aa4bd6486a1))

_ _ _ _

Resolves: #129 