### PR TITLE
Fix template postCommit for Ruby 2.7 / Bundler 2.2

### DIFF
--- a/openshift/templates/rails-postgresql-persistent.json
+++ b/openshift/templates/rails-postgresql-persistent.json
@@ -138,7 +138,7 @@
           }
         ],
         "postCommit": {
-          "script": "bundle exec rake test"
+          "script": "/usr/bin/bundle exec rake test"
         }
       }
     },

--- a/openshift/templates/rails-postgresql.json
+++ b/openshift/templates/rails-postgresql.json
@@ -138,7 +138,7 @@
           }
         ],
         "postCommit": {
-          "script": "bundle exec rake test"
+          "script": "/usr/bin/bundle exec rake test"
         }
       }
     },


### PR DESCRIPTION
A change in behaviour in Ruby 2.7's included bundler results in an error
in the postCommit stage when attempting to build the templates:

```
LoadError: cannot load such file -- bundler/setup
/opt/app-root/src/config/boot.rb:3:in `require'
/opt/app-root/src/config/boot.rb:3:in `<top (required)>'
/opt/app-root/src/config/application.rb:1:in `require_relative'
/opt/app-root/src/config/application.rb:1:in `<top (required)>'
/opt/app-root/src/Rakefile:4:in `require_relative'
/opt/app-root/src/Rakefile:4:in `<top (required)>'
/opt/app-root/src/bundle/ruby/2.7.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:63:in `load'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:63:in `kernel_load'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:28:in `run'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:475:in `exec'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:31:in `dispatch'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:25:in `start'
/usr/share/gems/gems/bundler-2.2.24/libexec/bundle:46:in `block in <top (required)>'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
/usr/share/gems/gems/bundler-2.2.24/libexec/bundle:34:in `<top (required)>'
/opt/app-root/src/bin/bundle:3:in `load'
/opt/app-root/src/bin/bundle:3:in `<main>'
```

This, or a better fix, is needed urgently in order to proceed with the 4.10 imagestreams sync.  Reverting the templates to 2.6 is not a great option given the upcoming EOL of that version.

/cc @phracek @pvalena @dperaza4dustbit @gabemontero 