### PR TITLE
Remove bundle wrapper script

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,0 @@
-#!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-load Gem.bin_path('bundler', 'bundle')


### PR DESCRIPTION
This script does not work with Ruby 2.7 / Bundler 2.2, and seems to be a relic from past Ruby and/or Rails versions.  All current versions of Ruby S2I images include a bundle command from their respective rubygem-bundler package.

With the script present, the following error occurs at various stages when using the templates:

```
LoadError: cannot load such file -- bundler/setup
/opt/app-root/src/config/boot.rb:3:in `require'
/opt/app-root/src/config/boot.rb:3:in `<top (required)>'
/opt/app-root/src/config/application.rb:1:in `require_relative'
/opt/app-root/src/config/application.rb:1:in `<top (required)>'
/opt/app-root/src/Rakefile:4:in `require_relative'
/opt/app-root/src/Rakefile:4:in `<top (required)>'
/opt/app-root/src/bundle/ruby/2.7.0/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:63:in `load'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:63:in `kernel_load'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli/exec.rb:28:in `run'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:475:in `exec'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:31:in `dispatch'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/cli.rb:25:in `start'
/usr/share/gems/gems/bundler-2.2.24/libexec/bundle:46:in `block in <top (required)>'
/usr/share/gems/gems/bundler-2.2.24/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
/usr/share/gems/gems/bundler-2.2.24/libexec/bundle:34:in `<top (required)>'
/opt/app-root/src/bin/bundle:3:in `load'
/opt/app-root/src/bin/bundle:3:in `<main>'
```
This replaces #140 as a solution to fixing the templates for 2.7, and would appear to be necessary regardless of #134.

/cc @phracek @pvalena @dperaza4dustbit @gabemontero
