### PR TITLE
Fix s2i assemble failing with Ruby 2.6.

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -14,7 +14,7 @@ if [ -f Gemfile ]; then
     # which bundler will no longer do in future versions.
     # Instead please use `bundle config set --local deployment 'true'`,
     # and stop using this flag
-    bundle config set --local deployment 'true'
+    bundle config --local deployment 'true'
   fi
 
   if [[ "$RAILS_ENV" == "development" || "$RACK_ENV" == "development" ]]; then
@@ -31,7 +31,7 @@ if [ -f Gemfile ]; then
     # which bundler will no longer do in future versions.
     # Instead please use `bundle config set --local without ''test''`,
     # and stop using this flag
-    bundle config set --local without "$BUNDLE_WITHOUT"
+    bundle config --local without "$BUNDLE_WITHOUT"
   fi
 
   echo "---> Running 'bundle install ${ADDTL_BUNDLE_ARGS}' ..."
@@ -40,7 +40,7 @@ if [ -f Gemfile ]; then
   # which bundler will no longer do in future versions.
   # Instead please use `bundle config set --local path './bundle'`,
   # and stop using this flag
-  bundle config set --local path './bundle'
+  bundle config --local path './bundle'
   bundle install ${ADDTL_BUNDLE_ARGS}
 
   echo "---> Cleaning up unused ruby gems ..."


### PR DESCRIPTION
Bundler v1.17 present with Ruby 2.6 interprets
"bundle config set path ./bundle" as "set" being the key
and "path ./bundle" being the value which is wrong for our use.

Using just `bundle config path ./bundle` works with new Rubies
as well as it fixes the behaviour on Ruby 2.6.

Since the variables were overwriting themselves and on the wrong key on top of that results in writing into the wrong directory,
where we do not have write permission at build time.

The built containers seem functional, the rails app starts up and shows the correct page.

s2i build logs:
Ruby 2.6 log: https://gist.github.com/jackorp/14de9fc2e4469d8edbd24d89555ae83b#file-s2i_ruby2-6-txt
Ruby 2.7 log: https://gist.github.com/jackorp/14de9fc2e4469d8edbd24d89555ae83b#file-s2i_ruby2-7-txt
Ruby 3.0 log: https://gist.github.com/jackorp/14de9fc2e4469d8edbd24d89555ae83b#file-s2i_ruby3-0-txt

Fixes: #146 