### PR TITLE
Restrict version of the pg gem to remain compatible with RHEL 7.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6'
 # Support postgresql as a database for Active Record
-gem 'pg'
+gem 'pg', '~> 1.2.0'
 # Support sqlite3 as a database for Active Record
 gem 'sqlite3'
 # Support redis as a key-value store for Action Cable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    i18n (1.10.0)
+    i18n (1.11.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -110,7 +110,7 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    pg (1.4.1)
+    pg (1.2.3)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -207,7 +207,7 @@ DEPENDENCIES
   ffi (>= 1.15.1)
   jbuilder
   listen
-  pg
+  pg (~> 1.2.0)
   puma
   rails (~> 6)
   redis


### PR DESCRIPTION
RHEL 7 ships with PGSQL 9.2, but pg gem supports only PGSQL 9.3
and higher since pg v1.3.0.

@pvalena FYI, since the testing PR failed, this should fix it. Confirmed that locally CentOS 7 Ruby containers pass the from-dockerfile test.