### PR TITLE
Bump ruby container from 2.7-ubi8 to 3.0-ubi8

### DIFF
--- a/openshift/templates/rails-postgresql-persistent.json
+++ b/openshift/templates/rails-postgresql-persistent.json
@@ -107,7 +107,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "ruby:2.7-ubi8"
+              "name": "ruby:3.0-ubi8"
             },
             "env": [
               {

--- a/openshift/templates/rails-postgresql.json
+++ b/openshift/templates/rails-postgresql.json
@@ -107,7 +107,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "${NAMESPACE}",
-              "name": "ruby:2.7-ubi8"
+              "name": "ruby:3.0-ubi8"
             },
             "env": [
               {


### PR DESCRIPTION
Bump ruby container from 2.7-ubi8 to 3.0-ubi8

This pull request bumps ruby container image in template from 2.7-ubi8 to 3.0-ubi8

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
