### PR TITLE
Make rails-ex work with Ruby 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6'
 # Support postgresql as a database for Active Record
-gem 'pg', '~> 1.2.0'
+gem 'pg'
 # Support sqlite3 as a database for Active Record
 gem 'sqlite3'
 # Support redis as a key-value store for Action Cable

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'jbuilder'
 gem 'listen'
 
 gem 'ffi', '>= 1.15.1'
+gem "sassc", "~> 2.1", "< 2.2"
 
 # ActiveRecord makes use of these bundled gems, as of Ruby 3.1, these requirements
 # have to be explicitly marked in a Gemfile.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
     digest (3.1.1)
@@ -177,7 +177,7 @@ GEM
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
+    sassc (2.1.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -200,7 +200,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
-    strscan (3.0.7)
+    strscan (3.0.8)
     thor (1.2.2)
     tilt (2.3.0)
     timeout (0.4.0)
@@ -240,6 +240,7 @@ DEPENDENCIES
   rails (~> 6)
   redis
   sass-rails
+  sassc (~> 2.1, < 2.2)
   selenium-webdriver
   spring
   spring-watcher-listen

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,9 +130,9 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    pg (1.2.3)
+    pg (1.5.4)
     public_suffix (4.0.7)
-    puma (6.4.0)
+    puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
@@ -173,7 +173,7 @@ GEM
       redis-client (>= 0.17.0)
     redis-client (0.19.1)
       connection_pool
-    regexp_parser (2.8.3)
+    regexp_parser (2.9.0)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -235,7 +235,7 @@ DEPENDENCIES
   listen
   matrix
   net-smtp
-  pg (~> 1.2.0)
+  pg
   puma
   rails (~> 6)
   redis


### PR DESCRIPTION
I have managed to make it work with Ruby 3.3!

It works with all the other Ruby versions as well. Test log: 
https://gist.github.com/pvalena/6834136128fb4fb131da6d779416831d

Ruby 3.3 PR & logs:: https://github.com/sclorg/s2i-ruby-container/pull/507
