### PR TITLE
Update SQLite to fix compilation on Fedora

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.7)
     minitest (5.15.0)
     net-imap (0.2.2)
       digest
@@ -127,8 +127,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.7.0)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.16.6)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     pg (1.5.4)
     public_suffix (4.0.7)
@@ -199,7 +199,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.4)
+    sqlite3 (2.0.2)
+      mini_portile2 (~> 2.8.0)
     strscan (3.1.0)
     thor (1.2.2)
     tilt (2.3.0)
@@ -249,3 +250,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   web-console
+
+BUNDLED WITH
+   2.5.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,6 +250,3 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   web-console
-
-BUNDLED WITH
-   2.5.14


### PR DESCRIPTION
Updating SQLite gem resolves problem with tests for _s2i-ruby-container_ - when using updated lock file, all tests are passing. This shouldn't really break the example app as _nokogiri_ doesn't really seem to be used directly, but there were changes (including deprecations) between the old and updated version (https://nokogiri.org/CHANGELOG.html).

Update on _nokogiri_ gem is forced due to shared dependency mini_portile2 between _nokogiri_ and sqlite3.

I am not sure whether this should also be in main branch, but it is not required to fix the sclorg/s2i-ruby-container#550 as only version 3.3 is failing the tests.

Fixes sclorg/s2i-ruby-container#550