### PR TITLE
OCPBUGS-39363: Use a supported ruby version in openshift templates

### DIFF
--- a/openshift/templates/rails-postgresql-persistent.json
+++ b/openshift/templates/rails-postgresql-persistent.json
@@ -528,9 +528,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.0-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.1-ubi8 by default).",
       "required": true,
-      "value": "3.0-ubi8"
+      "value": "3.1-ubi8"
     },
     {
       "name": "POSTGRESQL_VERSION",

--- a/openshift/templates/rails-postgresql.json
+++ b/openshift/templates/rails-postgresql.json
@@ -434,9 +434,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.0-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.1-ubi8 by default).",
       "required": true,
-      "value": "3.0-ubi8"
+      "value": "3.1-ubi8"
     },
     {
       "name": "MEMORY_LIMIT",

--- a/openshift/templates/rails.json
+++ b/openshift/templates/rails.json
@@ -214,9 +214,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.0-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.1-ubi8 by default).",
       "required": true,
-      "value": "3.0-ubi8"
+      "value": "3.1-ubi8"
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
This merely updates the default ruby version used in the rails samples to one supported in OpenShift.
