### PR TITLE
Switch from ubuntu-20.04 -> ubuntu-lastest

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -6,11 +6,11 @@ jobs:
   openshift-tests:
     # This job only runs for '[test] pull request comments by owner, member
     name: "RHEL9 tests: imagestream ${{ matrix.version }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        version: [ "2.5-ubi8", "3.1-ubi8", "3.0-ubi9", "3.1-ubi9", "3.3-ubi8", "3.3-ubi9" ]
+        version: [ "2.5-ubi8", "3.0-ubi9", "3.3-ubi8", "3.3-ubi9" ]
 
     if: |
       github.event.issue.pull_request


### PR DESCRIPTION
Ubuntu-20.04 was retired in March 2025 and therefore GitHub Actions are not executed at all


