### PR TITLE
Use a supported ruby version in openshift templates

### DIFF
--- a/openshift/templates/rails-postgresql-persistent.json
+++ b/openshift/templates/rails-postgresql-persistent.json
@@ -528,9 +528,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.3-ubi8 by default).",
       "required": true,
-      "value": "3.1-ubi8"
+      "value": "3.3-ubi8"
     },
     {
       "name": "POSTGRESQL_VERSION",
@@ -570,7 +570,8 @@
     {
       "name": "SOURCE_REPOSITORY_REF",
       "displayName": "Git Reference",
-      "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+      "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch.",
+      "value": "3.3"
     },
     {
       "name": "CONTEXT_DIR",

--- a/openshift/templates/rails-postgresql.json
+++ b/openshift/templates/rails-postgresql.json
@@ -503,9 +503,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.3-ubi8 by default).",
       "required": true,
-      "value": "3.1-ubi8"
+      "value": "3.3-ubi8"
     },
     {
       "name": "POSTGRESQL_VERSION",
@@ -538,7 +538,8 @@
     {
       "name": "SOURCE_REPOSITORY_REF",
       "displayName": "Git Reference",
-      "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+      "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch.",
+      "value": "3.3"
     },
     {
       "name": "CONTEXT_DIR",

--- a/openshift/templates/rails.json
+++ b/openshift/templates/rails.json
@@ -214,9 +214,9 @@
     {
       "name": "RUBY_VERSION",
       "displayName": "Ruby Version",
-      "description": "Version of Ruby image to be used (3.1-ubi8 by default).",
+      "description": "Version of Ruby image to be used (3.3-ubi8 by default).",
       "required": true,
-      "value": "3.1-ubi8"
+      "value": "3.3-ubi8"
     },
     {
       "name": "MEMORY_LIMIT",
@@ -235,7 +235,8 @@
     {
       "name": "SOURCE_REPOSITORY_REF",
       "displayName": "Git Reference",
-      "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
+      "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch.",
+      "value": "3.3"
     },
     {
       "name": "CONTEXT_DIR",


### PR DESCRIPTION
As ruby 3.1 ubi8 image is deprecated, we should bump the openshift template being used to a supported version like ruby 3.3-ubi8.

