### PR TITLE
Missing image name tag in templates

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TF_INTERNAL_API_KEY }}
-          compose: "RHEL-9.4.0-Nightly"
+          compose: "RHEL-9.6.0-Nightly"
           git_url: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
           git_ref: "master"
           tf_scope: "private"

--- a/openshift/templates/rails-postgresql-persistent.json
+++ b/openshift/templates/rails-postgresql-persistent.json
@@ -177,7 +177,7 @@
             "initContainers": [
               {
                 "name": "ruby-init-container",
-                "image": " ",
+                "image": "${NAME}:latest",
                 "command": [
                   "./migrate-database.sh"
                 ],
@@ -257,7 +257,7 @@
             "containers": [
               {
                 "name": "${NAME}",
-                "image": " ",
+                "image": "${NAME}:latest",
                 "ports": [
                   {
                     "containerPort": 8080

--- a/openshift/templates/rails.json
+++ b/openshift/templates/rails.json
@@ -155,8 +155,8 @@
           "spec": {
             "containers": [
               {
-                "name": "rails-example",
-                "image": " ",
+                "name": "${NAME}",
+                "image": "${NAME}:latest",
                 "ports": [
                   {
                     "containerPort": 8080


### PR DESCRIPTION
Image name tags are missing in the template definitions.

Fix Rails templates. Define image field to $NAME:latest

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
