### PR TITLE
Replace sass-rails with dartsass-sprockets for multi-arch support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'redis'
 # Use Puma as the app server
 gem 'puma'
 # Use SCSS for stylesheets
-gem 'sass-rails'
+gem 'dartsass-sprockets'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,9 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    bigdecimal (4.1.2)
     bindex (0.8.1)
-    builder (3.2.4)
+    builder (3.3.0)
     byebug (11.1.3)
     capybara (3.35.3)
       addressable
@@ -81,16 +82,34 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.6)
     connection_pool (2.4.1)
     crass (1.0.6)
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     digest (3.1.1)
-    erubi (1.12.0)
+    drb (2.2.3)
+    erubi (1.13.1)
     execjs (2.9.1)
-    ffi (1.16.3)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.1)
+    google-protobuf (4.34.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-wait (0.3.1)
     jbuilder (2.11.5)
@@ -99,7 +118,8 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.22.0)
+    logger (1.7.0)
+    loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -109,10 +129,12 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    method_source (1.0.0)
+    method_source (1.1.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
-    minitest (5.15.0)
+    mini_portile2 (2.8.9)
+    minitest (6.0.5)
+      drb (~> 2.0)
+      prism (~> 1.5)
     net-imap (0.2.2)
       digest
       net-protocol
@@ -127,16 +149,21 @@ GEM
       net-protocol
       timeout
     nio4r (2.7.0)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.19.3)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.19.3-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     pg (1.2.3)
+    prism (1.9.0)
     public_suffix (4.0.7)
     puma (6.4.0)
       nio4r (~> 2.0)
-    racc (1.7.3)
-    rack (2.2.8)
-    rack-test (2.1.0)
+    racc (1.8.1)
+    rack (2.2.23)
+    rack-test (2.2.0)
       rack (>= 1.3)
     rails (6.1.7.6)
       actioncable (= 6.1.7.6)
@@ -153,19 +180,20 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.7.6)
       sprockets-rails (>= 2.0.0)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.5.0)
-      loofah (~> 2.19, >= 2.19.1)
+    rails-html-sanitizer (1.7.0)
+      loofah (~> 2.25)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (6.1.7.6)
       actionpack (= 6.1.7.6)
       activesupport (= 6.1.7.6)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
-    rake (13.1.0)
+    rake (13.4.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -175,16 +203,15 @@ GEM
       connection_pool
     regexp_parser (2.8.3)
     rubyzip (2.3.2)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.99.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.99.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.99.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -192,17 +219,18 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (4.2.1)
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
+      logger
       rack (>= 2.2.4, < 4)
-    sprockets-rails (3.4.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
+    sprockets-rails (3.5.2)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.4)
     strscan (3.0.7)
-    thor (1.2.2)
-    tilt (2.3.0)
+    thor (1.5.0)
+    tilt (2.7.0)
     timeout (0.4.0)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
@@ -221,15 +249,18 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.12)
+    zeitwerk (2.7.5)
 
 PLATFORMS
+  aarch64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   byebug
   capybara
   coffee-rails
+  dartsass-sprockets
   ffi (>= 1.15.1)
   jbuilder
   listen
@@ -239,7 +270,6 @@ DEPENDENCIES
   puma
   rails (~> 6)
   redis
-  sass-rails
   selenium-webdriver
   spring
   spring-watcher-listen
@@ -248,3 +278,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier
   web-console
+
+BUNDLED WITH
+   2.5.22


### PR DESCRIPTION
## Problem

`sass-rails` depends on `sassc`, which bundles a native `libsass.so` compiled for x86_64 only. On aarch64 nodes in multi-arch CI runs, this causes a `LoadError` during `rake db:migrate`:

```
LoadError: Could not open library '.../gems/sassc-2.1.0/lib/sassc/libsass.so':
cannot open shared object file: No such file or directory
```

This breaks three OCP Component Readiness tests (all at 0% pass rate on 4.20+).

## Fix

Replace `sass-rails` with `dartsass-sprockets` — a drop-in replacement that uses Dart Sass via `sass-embedded`, which ships native binaries for both x86_64 and aarch64. Lockfile regenerated with both platforms.

## Jira

Fixes: [OCPBUGS-84740](https://issues.redhat.com/browse/OCPBUGS-84740)

---
🤖 *This PR was created by [OpenClaw](https://openclaw.ai) on behalf of @mkowalski.*