### PR TITLE
Add OpenShift versions 4.0-ubi9 and 4.0-ubi10 to tests

### DIFF
--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -5,12 +5,13 @@ on:
 jobs:
   openshift-tests:
     # This job only runs for '[test] pull request comments by owner, member
-    name: "RHEL9 tests: imagestream ${{ matrix.version }}"
+    name: "RHEL9 tests: pytest ${{ matrix.version }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        version: [ "2.5-ubi8", "3.0-ubi9", "3.3-ubi8", "3.3-ubi9", "3.3-ubi10", "4.0-ubi9", "4.0-ubi10" ]
+        version: [ "2.5", "3.0", "3.3", "4.0" ]
+        os: [ "rhel8", "rhel9", "rhel10" ]
 
     if: |
       github.event.issue.pull_request
@@ -23,8 +24,7 @@ jobs:
           compose: "RHEL-9.8.0-Nightly"
           git_url: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
           git_ref: "master"
-          tf_scope: "private"
           tmt_plan_regex: "rhel9-openshift-pytest"
           update_pull_request_status: true
           pull_request_status_name: "RHEL9-OpenShift-4 - PyTest ${{ matrix.version }}"
-          variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=rhel9;SINGLE_VERSION=${{ matrix.version }};TEST_NAME=test-openshift-pytest"
+          variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=${{ matrix.os }};SINGLE_VERSION=${{ matrix.version }};TEST_NAME=test-openshift-pytest"

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "2.5-ubi8", "3.0-ubi9", "3.3-ubi8", "3.3-ubi9", "3.3-ubi10" ]
+        version: [ "2.5-ubi8", "3.0-ubi9", "3.3-ubi8", "3.3-ubi9", "3.3-ubi10", "4.0-ubi9", "4.0-ubi10" ]
 
     if: |
       github.event.issue.pull_request
@@ -20,11 +20,11 @@ jobs:
       - uses: sclorg/testing-farm-as-github-action@main
         with:
           api_key: ${{ secrets.TF_INTERNAL_API_KEY }}
-          compose: "RHEL-9.6.0-Nightly"
+          compose: "RHEL-9.8.0-Nightly"
           git_url: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
           git_ref: "master"
           tf_scope: "private"
           tmt_plan_regex: "rhel9-openshift-pytest"
           update_pull_request_status: true
-          pull_request_status_name: "RHEL9-OpenShift-4 - imagestream test ${{ matrix.version }}"
+          pull_request_status_name: "RHEL9-OpenShift-4 - PyTest ${{ matrix.version }}"
           variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};REPO_NAME=${{ github.repository }};PR_NUMBER=${{ github.event.issue.number }};OS=rhel9;SINGLE_VERSION=${{ matrix.version }};TEST_NAME=test-openshift-pytest"


### PR DESCRIPTION
Update also compose to RHEL-9.8

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched OpenShift testing workflow from imagestream to pytest-based testing
  * Expanded test coverage across RHEL 8, 9, and 10 with product versions 2.5, 3.0, 3.3, and 4.0
  * Upgraded testing environment to use RHEL 9.8.0 nightly compose

<!-- end of auto-generated comment: release notes by coderabbit.ai -->